### PR TITLE
feat: cancel lame searches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,6 +256,18 @@ version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "env_logger"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "failure"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -446,6 +458,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "humantime"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "itertools"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -546,12 +566,27 @@ version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "pretty_env_logger"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "quote"
@@ -679,10 +714,10 @@ dependencies = [
  "gtk 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pretty_env_logger 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rff 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "simple_logger 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sublime_fuzzy 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -736,15 +771,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "simple_logger"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "strsim"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -773,6 +799,14 @@ dependencies = [
  "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "wincolor 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -882,6 +916,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
+[[package]]
+name = "wincolor"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
 [metadata]
 "checksum aho-corasick 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "81ce3d38065e618af2d7b77e10c5ad9a069859b4be3c2250f674af3840d9c8a5"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
@@ -910,6 +953,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum csv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f0782c7154d8dd08f4adeb5aa22ab178c10281915f7da68d10bb646f03aaee73"
 "checksum csv-core 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fa5cdef62f37e6ffe7d1f07a381bc0db32b7a3ff1cac0de56cb0d81e71f53d65"
 "checksum either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5527cfe0d098f36e3f8839852688e63c8fff1c90b2b405aef730615f9a7bcf7b"
+"checksum env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum fragile 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05f8140122fa0d5dcb9fc8627cfce2b37cc1500f752636d46ea28bc26785c2f9"
@@ -925,6 +969,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum gobject-sys 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "23e05a14290d3dc255223cba51db4b0f3da438d5250657996fa99b2a30faf43e"
 "checksum gtk 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b52cfbd8c3e4a000c8374676352f3850c2d62c0f42ef0a993e5d3fcf47e0be64"
 "checksum gtk-sys 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "849835f05d46f605b00ee9fefb6d5921238c570af406f35ee7426ed01cd6795c"
+"checksum humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
 "checksum itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b8467d9c1cebe26feb08c640139247fac215782d35371ade9a2136ed6085358"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
@@ -939,7 +984,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum pango 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4e36b55d7cd522bd183efeb3dfabc547bda1f26eadf8a1241dac09ab3fd3242c"
 "checksum pango-sys 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "747ab9cd4d537e6dc5ef0e4308c10dde8b706673b0237fed4e056b8d2c0b23c8"
 "checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
+"checksum pretty_env_logger 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "717ee476b1690853d222af4634056d830b5197ffd747726a9a1eee6da9f49074"
 "checksum proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)" = "4d317f9caece796be1980837fd5cb3dfec5613ebdb04ad0956deea83ce168915"
+"checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "cdd8e04bd9c52e0342b406469d494fcb033be4bdbe5c606016defbb1681411e1"
 "checksum rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
 "checksum rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d0e7a549d590831370895ab7ba4ea0c1b6b011d106b5ff2da6eee112615e6dc0"
@@ -960,11 +1007,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)" = "aa5f7c20820475babd2c077c3ab5f8c77a31c15e16ea38687b4c02d3e48680f4"
 "checksum serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)" = "58fc82bec244f168b23d1963b45c8bf5726e9a15a9d146a067f9081aeed2de79"
 "checksum serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)" = "5a23aa71d4a4d43fdbfaac00eff68ba8a06a51759a89ac3304323e800c4dd40d"
-"checksum simple_logger 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "25111f1d77db1ac3ee11b62ba4b7a162e6bb3be43e28273f0d3935cc8d3ff7fb"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum sublime_fuzzy 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bdac3d983d073c19487ba1f5e16eda43e9c6e50aa895d87110d0febe389b66b9"
 "checksum syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)" = "1825685f977249735d510a242a6727b46efe914bb67e38d30c071b1b72b1d5c2"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
+"checksum termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
@@ -980,3 +1027,4 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7168bab6e1daee33b4557efd0e95d5ca70a03706d39fa5f3fe7a236f584b03c9"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+"checksum wincolor 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "96f5016b18804d24db43cebf3c77269e7569b8954a8464501c216cc5e070eaa9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,11 @@ failure = "0.1"
 gdk = "0.10.0"
 glib = "0.7.0"
 lazy_static = "1.3.0"
-log = { version = "0.4", features = ["max_level_trace", "release_max_level_warn"] }
+log = "0.4"
+pretty_env_logger = "0.3"
 regex = "1"
 rff = "0.3.0"
 rayon = "1.0.0"
-simple_logger = "1.0.1"
 sublime_fuzzy = "0.6.0"
 walkdir = "2"
 

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -8,6 +8,7 @@ use std::path::PathBuf;
 use riiry::applications;
 use riiry::files;
 use riiry::filter;
+use riiry::worker::Cancel;
 
 fn pathbufs_to_vecstr(pathbufs: Vec<PathBuf>) -> Vec<String> {
     pathbufs
@@ -59,7 +60,7 @@ fn bench_filter_lines_apps_rff(c: &mut Criterion) {
     c.bench_function("bench_filter_lines_apps_rff()", move |b| {
         b.iter_batched(
             || haystack.clone(),
-            |apps| filter::filter_lines_rff("firefox", &apps),
+            |apps| filter::filter_lines_rff("firefox", &apps, Cancel::Never),
             BatchSize::NumIterations(1),
         )
     });

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -60,7 +60,7 @@ fn bench_filter_lines_apps_rff(c: &mut Criterion) {
     c.bench_function("bench_filter_lines_apps_rff()", move |b| {
         b.iter_batched(
             || haystack.clone(),
-            |apps| filter::filter_lines_rff("firefox", &apps, Cancel::Never),
+            |apps| filter::filter_lines_rff("firefox", &apps, &Cancel::Never),
             BatchSize::NumIterations(1),
         )
     });

--- a/src/files.rs
+++ b/src/files.rs
@@ -3,6 +3,7 @@ use failure::Error;
 use failure::ResultExt;
 use glib::Sender;
 use log::debug;
+use log::trace;
 use std::env;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -46,7 +47,7 @@ pub fn get_home_files_incremental(tx: Sender<Vec<String>>) {
             .filter_entry(|e| is_not_hidden(e))
             .filter_map(|e| e.ok())
         {
-            debug!("{}", entry.path().display());
+            trace!("path: {}", entry.path().display());
             // tx.send(vec![String::from(entry.path().to_str().unwrap()) + "\n"]);
             tx.send(vec![String::from(entry.path().to_str().unwrap())]);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,3 +8,5 @@ extern crate regex;
 pub mod applications;
 pub mod files;
 pub mod filter;
+
+pub mod worker;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,5 @@
 #[macro_use]
 extern crate lazy_static;
-extern crate log;
-extern crate regex;
-extern crate simple_logger;
 
 pub mod applications;
 pub mod files;
@@ -22,7 +19,7 @@ pub mod worker;
 // - Windows + OSX: https://crates.io/crates/directories
 
 fn main() {
-    simple_logger::init().unwrap();
+    pretty_env_logger::init();
     // simple_logger::init_with_level(log::Level::Warn).unwrap();
 
     // Initialize the UI's initial state

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,8 @@ pub mod filter;
 pub mod state;
 pub mod ui;
 
+pub mod worker;
+
 // TODO: Finish working through this tutorial:
 // https://mmstick.github.io/gtkrs-tutorials/introduction.html
 //

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,6 +1,9 @@
+use super::worker::Worker;
+
 pub struct RiiryState {
     haystack: Vec<String>,
     needle: String,
+    pub search_worker: Worker,
 }
 
 impl RiiryState {
@@ -8,6 +11,7 @@ impl RiiryState {
         RiiryState {
             haystack: Vec::new(),
             needle: String::new(),
+            search_worker: Worker::default(),
         }
     }
 

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -188,10 +188,12 @@ impl App {
                 .unwrap()
                 .search_worker
                 .run(move |cancel| {
-                    let results = filter::filter_lines_rff(&query, &vec, cancel);
+                    let results = filter::filter_lines_rff(&query, &vec, &cancel);
                     //debug!("{:?}", results);
 
-                    tx.send(results);
+                    if let Some(results) = results {
+                        let _ = tx.send(results);
+                    }
                 });
 
             {

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -183,12 +183,16 @@ impl App {
             let vec = riirystate.read().unwrap().get_haystack().clone();
 
             let (tx, rx) = glib::MainContext::channel(glib::PRIORITY_DEFAULT);
-            thread::spawn(move || {
-                let results = filter::filter_lines_rff(&query, &vec);
-                //debug!("{:?}", results);
+            riirystate
+                .write()
+                .unwrap()
+                .search_worker
+                .run(move |cancel| {
+                    let results = filter::filter_lines_rff(&query, &vec, cancel);
+                    //debug!("{:?}", results);
 
-                tx.send(results);
-            });
+                    tx.send(results);
+                });
 
             {
                 let textview = textview.clone();

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -5,6 +5,8 @@ use std::sync::Mutex;
 use std::thread;
 use std::thread::JoinHandle;
 
+use log::info;
+
 #[derive(Default)]
 pub struct Worker {
     cancellation: Option<mpsc::Sender<()>>,
@@ -17,6 +19,7 @@ impl Worker {
         T: 'static + Send,
     {
         if let Some(cancellation) = self.cancellation.as_mut() {
+            info!("asking existing worker to cancel");
             let _ = cancellation.send(());
         }
         let (cancellation, done) = mpsc::channel();

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1,0 +1,47 @@
+use std::sync::mpsc;
+use std::sync::mpsc::TryRecvError;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::thread;
+use std::thread::JoinHandle;
+
+#[derive(Default)]
+pub struct Worker {
+    cancellation: Option<mpsc::Sender<()>>,
+}
+
+impl Worker {
+    pub fn run<F, T>(&mut self, func: F) -> JoinHandle<T>
+    where
+        F: 'static + Send + FnOnce(Cancel) -> T,
+        T: 'static + Send,
+    {
+        if let Some(cancellation) = self.cancellation.as_mut() {
+            let _ = cancellation.send(());
+        }
+        let (cancellation, done) = mpsc::channel();
+        self.cancellation = Some(cancellation);
+        thread::spawn(move || func(Cancel::OnMessage(Arc::new(Mutex::new(done)))))
+    }
+}
+
+pub enum Cancel {
+    OnMessage(Arc<Mutex<mpsc::Receiver<()>>>),
+    Never,
+}
+
+impl Cancel {
+    pub fn check_done(&self) -> bool {
+        match self {
+            Cancel::OnMessage(done) => match done.lock().unwrap().try_recv() {
+                Ok(()) | Err(TryRecvError::Disconnected) => true,
+                Err(TryRecvError::Empty) => false,
+            },
+            Cancel::Never => false,
+        }
+    }
+
+    pub fn maybe_abort(&self) {
+        assert!(!self.check_done())
+    }
+}


### PR DESCRIPTION
When a search is scheduled, cancel any running existing search.

This is done by messaging the existing thread, and asking it to do nothing. The filter code is changed to check if it's been asked to cancel, and, if it has, not send any answers, and exit as soon as possible.

The exiting isn't particularly nice. Nor is the code in the cancellation, was hoping to avoid that `Mutex` but it wouldn't play nice with Rayon.

I don't think parallel sort or to_string is helping there.

I changed the logging for env-logger so I could see what's going on, because it's not a work day and screw neat PRs.